### PR TITLE
feat: `ghi link` の `--blocked-by` 対応と両経路試行時の失敗制御を追加

### DIFF
--- a/cmd/ghi/link_test.go
+++ b/cmd/ghi/link_test.go
@@ -2,18 +2,26 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nomnel/ghi/internal/filefmt"
-	"github.com/nomnel/ghi/internal/gh"
 	"github.com/nomnel/ghi/internal/model"
 	"github.com/spf13/cobra"
 )
 
-func prepareLinkFixture(t *testing.T, parent *int) string {
+func setupLinkWorkspace(t *testing.T) {
 	t.Helper()
+
+	resetDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to capture cwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(resetDir) })
 
 	dir := t.TempDir()
 	if err := os.Chdir(dir); err != nil {
@@ -23,15 +31,17 @@ func prepareLinkFixture(t *testing.T, parent *int) string {
 	if err := os.MkdirAll("issues", 0o755); err != nil {
 		t.Fatalf("failed to create issues dir: %v", err)
 	}
+}
 
-	fm := model.Frontmatter{Title: "Child title", Parent: parent}
-	body := []byte("child body")
-	content, err := filefmt.EncodeMarkdown(fm, body)
+func writeIssueFixture(t *testing.T, issueNumber int, fm model.Frontmatter, body string) string {
+	t.Helper()
+
+	content, err := filefmt.EncodeMarkdown(fm, []byte(body))
 	if err != nil {
 		t.Fatalf("failed to encode fixture: %v", err)
 	}
 
-	path := filepath.Join("issues", "5.md")
+	path := filepath.Join("issues", fmt.Sprintf("%d.md", issueNumber))
 	if err := os.WriteFile(path, content, 0o644); err != nil {
 		t.Fatalf("failed to write fixture: %v", err)
 	}
@@ -39,202 +49,414 @@ func prepareLinkFixture(t *testing.T, parent *int) string {
 	return path
 }
 
-func writeCustomMarkdown(t *testing.T, content string) string {
+func writeIssueRaw(t *testing.T, issueNumber int, content string) string {
 	t.Helper()
 
-	dir := t.TempDir()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("failed to chdir: %v", err)
-	}
-
-	if err := os.MkdirAll("issues", 0o755); err != nil {
-		t.Fatalf("failed to create issues dir: %v", err)
-	}
-
-	path := filepath.Join("issues", "5.md")
+	path := filepath.Join("issues", fmt.Sprintf("%d.md", issueNumber))
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("failed to write custom markdown: %v", err)
+		t.Fatalf("failed to write issue markdown: %v", err)
 	}
 
 	return path
 }
 
-func TestRunLinkAddsParentAndUpdatesFile(t *testing.T) {
-	resetDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to capture cwd: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(resetDir) })
+func newLinkTestCommand(t *testing.T, parent string, blockedBy []string, dependsOn []string) *cobra.Command {
+	t.Helper()
 
-	path := prepareLinkFixture(t, nil)
+	cmd := &cobra.Command{}
+	cmd.Flags().String("parent", "", "")
+	cmd.Flags().StringArray("blocked-by", nil, "")
+	cmd.Flags().StringArray("depends-on", nil, "")
 
-	called := false
-	addSubIssueFn = func(child, parent string) error {
-		called = true
-		if child != "5" || parent != "7" {
-			t.Fatalf("unexpected parameters child=%s parent=%s", child, parent)
+	if parent != "" {
+		if err := cmd.Flags().Set("parent", parent); err != nil {
+			t.Fatalf("failed to set parent flag: %v", err)
 		}
-		return nil
 	}
-	t.Cleanup(func() { addSubIssueFn = gh.AddSubIssue })
-
-	cmd := &cobra.Command{}
-	cmd.Flags().String("parent", "", "")
-	cmd.Flags().Set("parent", "7")
-
-	if err := runLink(cmd, []string{"5"}); err != nil {
-		t.Fatalf("runLink returned error: %v", err)
-	}
-
-	if !called {
-		t.Fatalf("expected AddSubIssue to be called")
-	}
-
-	updated, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read updated file: %v", err)
-	}
-
-	expected := "---\ntitle: Child title\nparent: 7\n---\nchild body"
-	if string(updated) != expected {
-		t.Fatalf("frontmatter order or content mismatch\nexpected:\n%s\nactual:\n%s", expected, string(updated))
-	}
-}
-
-func TestRunLinkPreservesFrontmatterOrderAndUnknownKeys(t *testing.T) {
-	resetDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to capture cwd: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(resetDir) })
-
-	initial := "---\ntitle: Child title\nlabels:\n  - foo\ncustom: bar\n---\nbody"
-	path := writeCustomMarkdown(t, initial)
-
-	called := false
-	addSubIssueFn = func(child, parent string) error {
-		called = true
-		if child != "5" || parent != "7" {
-			t.Fatalf("unexpected parameters child=%s parent=%s", child, parent)
+	for _, blocker := range blockedBy {
+		if err := cmd.Flags().Set("blocked-by", blocker); err != nil {
+			t.Fatalf("failed to set blocked-by flag: %v", err)
 		}
-		return nil
 	}
-	t.Cleanup(func() { addSubIssueFn = gh.AddSubIssue })
-
-	cmd := &cobra.Command{}
-	cmd.Flags().String("parent", "", "")
-	cmd.Flags().Set("parent", "7")
-
-	if err := runLink(cmd, []string{"5"}); err != nil {
-		t.Fatalf("runLink returned error: %v", err)
+	for _, dep := range dependsOn {
+		if err := cmd.Flags().Set("depends-on", dep); err != nil {
+			t.Fatalf("failed to set depends-on flag: %v", err)
+		}
 	}
 
-	if !called {
-		t.Fatalf("expected AddSubIssue to be called")
-	}
-
-	updated, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read updated file: %v", err)
-	}
-
-	expected := "---\ntitle: Child title\nlabels:\n  - foo\ncustom: bar\nparent: 7\n---\nbody"
-	if string(updated) != expected {
-		t.Fatalf("frontmatter order or content mismatch\nexpected:\n%s\nactual:\n%s", expected, string(updated))
-	}
+	return cmd
 }
 
-func TestRunLinkSkipsWhenAlreadyLinked(t *testing.T) {
-	resetDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to capture cwd: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(resetDir) })
+func stubLinkFns(t *testing.T, subIssue func(string, string) error, blockedBy func(string, string) error) {
+	t.Helper()
 
-	parent := 7
-	path := prepareLinkFixture(t, &parent)
+	origSub := addSubIssueFn
+	origBlocked := addBlockedByFn
 
-	addSubIssueFn = func(_, _ string) error {
-		t.Fatalf("AddSubIssue should not be called when parent matches")
-		return nil
-	}
-	t.Cleanup(func() { addSubIssueFn = gh.AddSubIssue })
+	addSubIssueFn = subIssue
+	addBlockedByFn = blockedBy
 
-	cmd := &cobra.Command{}
-	cmd.Flags().String("parent", "", "")
-	cmd.Flags().Set("parent", "7")
-
-	if err := runLink(cmd, []string{"5"}); err != nil {
-		t.Fatalf("runLink returned error: %v", err)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
-
-	expected := "---\ntitle: Child title\nparent: 7\n---\nchild body"
-	if string(data) != expected {
-		t.Fatalf("file should remain unchanged\nexpected:\n%s\nactual:\n%s", expected, string(data))
-	}
+	t.Cleanup(func() {
+		addSubIssueFn = origSub
+		addBlockedByFn = origBlocked
+	})
 }
 
-func TestRunLinkRejectsSameNumbers(t *testing.T) {
-	resetDir, err := os.Getwd()
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("failed to capture cwd: %v", err)
+		t.Fatalf("failed to create pipe: %v", err)
 	}
-	t.Cleanup(func() { os.Chdir(resetDir) })
+	os.Stdout = w
 
-	prepareLinkFixture(t, nil)
+	runErr := fn()
 
-	cmd := &cobra.Command{}
-	cmd.Flags().String("parent", "", "")
-	cmd.Flags().Set("parent", "5")
+	_ = w.Close()
+	os.Stdout = orig
 
-	err = runLink(cmd, []string{"5"})
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+	_ = r.Close()
+
+	return string(out), runErr
+}
+
+func expectExitCode(t *testing.T, err error, code model.ErrorType) {
+	t.Helper()
+
 	if err == nil {
-		t.Fatalf("expected usage error when child equals parent")
+		t.Fatalf("expected error, got nil")
 	}
 
 	exitErr, ok := err.(*model.ExitError)
 	if !ok {
 		t.Fatalf("expected ExitError, got %T", err)
 	}
-	if exitErr.Code != model.ExitUsage {
-		t.Fatalf("expected usage exit code, got %v", exitErr.Code)
+	if exitErr.Code != code {
+		t.Fatalf("unexpected exit code: got=%v want=%v", exitErr.Code, code)
 	}
 }
 
-func TestRunLinkLeavesFileUntouchedWhenRemoteLinkFails(t *testing.T) {
-	resetDir, err := os.Getwd()
+func TestRunLinkParentOnly(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	path := writeIssueFixture(t, 5, model.Frontmatter{Title: "Child title"}, "child body")
+
+	called := false
+	stubLinkFns(t,
+		func(child, parent string) error {
+			called = true
+			if child != "5" || parent != "7" {
+				t.Fatalf("unexpected sub-issue params: child=%s parent=%s", child, parent)
+			}
+			return nil
+		},
+		func(_, _ string) error {
+			t.Fatalf("AddBlockedBy should not be called")
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", nil, nil)
+	if _, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) }); err != nil {
+		t.Fatalf("runLink returned error: %v", err)
+	}
+
+	if !called {
+		t.Fatalf("expected AddSubIssue to be called")
+	}
+
+	updated, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("failed to capture cwd: %v", err)
-	}
-	t.Cleanup(func() { os.Chdir(resetDir) })
-
-	initial := "---\ntitle: Child title\nextra: keep-me\n---\nbody"
-	path := writeCustomMarkdown(t, initial)
-
-	addSubIssueFn = func(_, _ string) error {
-		return errors.New("remote failure")
-	}
-	t.Cleanup(func() { addSubIssueFn = gh.AddSubIssue })
-
-	cmd := &cobra.Command{}
-	cmd.Flags().String("parent", "", "")
-	cmd.Flags().Set("parent", "7")
-
-	err = runLink(cmd, []string{"5"})
-	if err == nil {
-		t.Fatalf("expected error when AddSubIssue fails")
+		t.Fatalf("failed to read updated file: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	expected := "---\ntitle: Child title\nparent: 7\n---\nchild body"
+	if string(updated) != expected {
+		t.Fatalf("unexpected content\nexpected:\n%s\nactual:\n%s", expected, string(updated))
+	}
+}
+
+func TestRunLinkBlockedByOnlyUsesURLAndMergesBlockedBy(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	initial := "---\ntitle: Child title\ncustom: keep\nblocked_by: [10, 3]\n---\nchild body"
+	path := writeIssueRaw(t, 5, initial)
+
+	var calls []string
+	stubLinkFns(t,
+		func(_, _ string) error {
+			t.Fatalf("AddSubIssue should not be called")
+			return nil
+		},
+		func(issue, blocker string) error {
+			calls = append(calls, issue+"<-"+blocker)
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "", []string{
+		"https://github.com/org/repo/issues/8",
+		"8",
+		"3",
+	}, nil)
+
+	out, err := captureStdout(t, func() error {
+		return runLink(cmd, []string{"https://github.com/org/repo/issues/5"})
+	})
 	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
+		t.Fatalf("runLink returned error: %v", err)
 	}
 
+	if len(calls) != 1 || calls[0] != "5<-8" {
+		t.Fatalf("unexpected blocked-by calls: %v", calls)
+	}
+
+	expectedSummary := "link summary: parent=not-requested blocked_by_added=1/2 partial_success=no\n"
+	if out != expectedSummary {
+		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read updated file: %v", err)
+	}
+
+	expected := "---\ntitle: Child title\ncustom: keep\nblocked_by: [3, 8, 10]\n---\nchild body"
+	if string(updated) != expected {
+		t.Fatalf("unexpected content\nexpected:\n%s\nactual:\n%s", expected, string(updated))
+	}
+}
+
+func TestRunLinkParentAndBlockedBySuccess(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	path := writeIssueFixture(t, 5, model.Frontmatter{Title: "Child title"}, "child body")
+
+	subCalled := false
+	blockedCalled := false
+	stubLinkFns(t,
+		func(child, parent string) error {
+			subCalled = true
+			if child != "5" || parent != "7" {
+				t.Fatalf("unexpected sub-issue params: child=%s parent=%s", child, parent)
+			}
+			return nil
+		},
+		func(issue, blocker string) error {
+			blockedCalled = true
+			if issue != "5" || blocker != "9" {
+				t.Fatalf("unexpected blocked-by params: issue=%s blocker=%s", issue, blocker)
+			}
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", []string{"9"}, nil)
+	out, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) })
+	if err != nil {
+		t.Fatalf("runLink returned error: %v", err)
+	}
+
+	if !subCalled || !blockedCalled {
+		t.Fatalf("expected both AddSubIssue and AddBlockedBy to be called")
+	}
+
+	expectedSummary := "link summary: parent=added blocked_by_added=1/1 partial_success=no\n"
+	if out != expectedSummary {
+		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read updated file: %v", err)
+	}
+
+	expected := "---\ntitle: Child title\nparent: 7\nblocked_by: [9]\n---\nchild body"
+	if string(updated) != expected {
+		t.Fatalf("unexpected content\nexpected:\n%s\nactual:\n%s", expected, string(updated))
+	}
+}
+
+func TestRunLinkRequiresAtLeastOneLinkOption(t *testing.T) {
+	setupLinkWorkspace(t)
+	writeIssueFixture(t, 5, model.Frontmatter{Title: "Child title"}, "child body")
+
+	stubLinkFns(t,
+		func(_, _ string) error {
+			t.Fatalf("AddSubIssue should not be called")
+			return nil
+		},
+		func(_, _ string) error {
+			t.Fatalf("AddBlockedBy should not be called")
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "", nil, nil)
+	err := runLink(cmd, []string{"5"})
+	expectExitCode(t, err, model.ExitUsage)
+}
+
+func TestRunLinkRejectsDependsOnFlag(t *testing.T) {
+	setupLinkWorkspace(t)
+	writeIssueFixture(t, 5, model.Frontmatter{Title: "Child title"}, "child body")
+
+	cmd := newLinkTestCommand(t, "", nil, []string{"8"})
+	err := runLink(cmd, []string{"5"})
+	expectExitCode(t, err, model.ExitUsage)
+
+	if !strings.Contains(err.Error(), "--depends-on is not supported") {
+		t.Fatalf("expected unsupported --depends-on message, got: %v", err)
+	}
+}
+
+func TestRunLinkValidationsSkipAPI(t *testing.T) {
+	testCases := []struct {
+		name      string
+		args      []string
+		parent    string
+		blockedBy []string
+	}{
+		{name: "issue equals parent", args: []string{"5"}, parent: "5"},
+		{name: "blocked-by contains issue", args: []string{"5"}, blockedBy: []string{"5"}},
+		{name: "blocked-by contains parent", args: []string{"5"}, parent: "7", blockedBy: []string{"7"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupLinkWorkspace(t)
+			writeIssueFixture(t, 5, model.Frontmatter{Title: "Child title"}, "child body")
+
+			subCalls := 0
+			blockedCalls := 0
+			stubLinkFns(t,
+				func(_, _ string) error {
+					subCalls++
+					return nil
+				},
+				func(_, _ string) error {
+					blockedCalls++
+					return nil
+				},
+			)
+
+			cmd := newLinkTestCommand(t, tc.parent, tc.blockedBy, nil)
+			err := runLink(cmd, tc.args)
+			expectExitCode(t, err, model.ExitUsage)
+
+			if subCalls != 0 || blockedCalls != 0 {
+				t.Fatalf("API should not be called on validation failure: sub=%d blocked=%d", subCalls, blockedCalls)
+			}
+		})
+	}
+}
+
+func TestRunLinkKeepsBlockedByWhenFlagIsNotProvided(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	initial := "---\ntitle: Child title\nblocked_by:\n  - 4\n  - 2\n---\nchild body"
+	path := writeIssueRaw(t, 5, initial)
+
+	stubLinkFns(t,
+		func(child, parent string) error {
+			if child != "5" || parent != "7" {
+				t.Fatalf("unexpected sub-issue params: child=%s parent=%s", child, parent)
+			}
+			return nil
+		},
+		func(_, _ string) error {
+			t.Fatalf("AddBlockedBy should not be called")
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", nil, nil)
+	if _, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) }); err != nil {
+		t.Fatalf("runLink returned error: %v", err)
+	}
+
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read updated file: %v", err)
+	}
+
+	expected := "---\ntitle: Child title\nblocked_by:\n  - 4\n  - 2\nparent: 7\n---\nchild body"
+	if string(updated) != expected {
+		t.Fatalf("blocked_by should remain unchanged when flag is omitted\nexpected:\n%s\nactual:\n%s", expected, string(updated))
+	}
+}
+
+func TestRunLinkLeavesFileUntouchedWhenRemoteFailsAfterPartialSuccess(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	initial := "---\ntitle: Child title\nextra: keep\n---\nbody"
+	path := writeIssueRaw(t, 5, initial)
+
+	stubLinkFns(t,
+		func(child, parent string) error {
+			if child != "5" || parent != "7" {
+				t.Fatalf("unexpected sub-issue params: child=%s parent=%s", child, parent)
+			}
+			return nil
+		},
+		func(_, _ string) error {
+			return errors.New("blocked-by failure")
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", []string{"9"}, nil)
+	out, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) })
+	expectExitCode(t, err, model.ExitEnv)
+
+	expectedSummary := "link summary: parent=added blocked_by_added=0/1 partial_success=yes\n"
+	if out != expectedSummary {
+		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("failed to read file: %v", readErr)
+	}
+	if string(data) != initial {
+		t.Fatalf("file should remain unchanged after remote failure\nexpected:\n%s\nactual:\n%s", initial, string(data))
+	}
+}
+
+func TestRunLinkLeavesFileUntouchedWhenParentLinkFails(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	initial := "---\ntitle: Child title\nextra: keep\n---\nbody"
+	path := writeIssueRaw(t, 5, initial)
+
+	stubLinkFns(t,
+		func(_, _ string) error {
+			return errors.New("parent failure")
+		},
+		func(_, _ string) error {
+			t.Fatalf("AddBlockedBy should not be called when parent link fails first")
+			return nil
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", []string{"9"}, nil)
+	out, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) })
+	expectExitCode(t, err, model.ExitEnv)
+
+	expectedSummary := "link summary: parent=failed blocked_by_added=0/1 partial_success=no\n"
+	if out != expectedSummary {
+		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("failed to read file: %v", readErr)
+	}
 	if string(data) != initial {
 		t.Fatalf("file should remain unchanged after remote failure\nexpected:\n%s\nactual:\n%s", initial, string(data))
 	}

--- a/cmd/ghi/link_test.go
+++ b/cmd/ghi/link_test.go
@@ -428,18 +428,22 @@ func TestRunLinkLeavesFileUntouchedWhenRemoteFailsAfterPartialSuccess(t *testing
 	}
 }
 
-func TestRunLinkLeavesFileUntouchedWhenParentLinkFails(t *testing.T) {
+func TestRunLinkLeavesFileUntouchedWhenParentLinkFailsButBlockedBySucceeds(t *testing.T) {
 	setupLinkWorkspace(t)
 
 	initial := "---\ntitle: Child title\nextra: keep\n---\nbody"
 	path := writeIssueRaw(t, 5, initial)
 
+	blockedCalls := 0
 	stubLinkFns(t,
 		func(_, _ string) error {
 			return errors.New("parent failure")
 		},
-		func(_, _ string) error {
-			t.Fatalf("AddBlockedBy should not be called when parent link fails first")
+		func(issue, blocker string) error {
+			blockedCalls++
+			if issue != "5" || blocker != "9" {
+				t.Fatalf("unexpected blocked-by params: issue=%s blocker=%s", issue, blocker)
+			}
 			return nil
 		},
 	)
@@ -448,9 +452,57 @@ func TestRunLinkLeavesFileUntouchedWhenParentLinkFails(t *testing.T) {
 	out, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) })
 	expectExitCode(t, err, model.ExitEnv)
 
-	expectedSummary := "link summary: parent=failed blocked_by_added=0/1 partial_success=no\n"
+	if blockedCalls != 1 {
+		t.Fatalf("expected AddBlockedBy to be called once, got %d", blockedCalls)
+	}
+
+	expectedSummary := "link summary: parent=failed blocked_by_added=1/1 partial_success=yes\n"
 	if out != expectedSummary {
 		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("failed to read file: %v", readErr)
+	}
+	if string(data) != initial {
+		t.Fatalf("file should remain unchanged after remote failure\nexpected:\n%s\nactual:\n%s", initial, string(data))
+	}
+}
+
+func TestRunLinkAggregatesFailuresAfterTryingBothLinkPaths(t *testing.T) {
+	setupLinkWorkspace(t)
+
+	initial := "---\ntitle: Child title\nextra: keep\n---\nbody"
+	path := writeIssueRaw(t, 5, initial)
+
+	var blockedCalls []string
+	stubLinkFns(t,
+		func(_, _ string) error {
+			return errors.New("parent failure")
+		},
+		func(issue, blocker string) error {
+			blockedCalls = append(blockedCalls, issue+"<-"+blocker)
+			return errors.New("blocked-by failure " + blocker)
+		},
+	)
+
+	cmd := newLinkTestCommand(t, "7", []string{"11", "9"}, nil)
+	out, err := captureStdout(t, func() error { return runLink(cmd, []string{"5"}) })
+	expectExitCode(t, err, model.ExitEnv)
+
+	if len(blockedCalls) != 2 || blockedCalls[0] != "5<-9" || blockedCalls[1] != "5<-11" {
+		t.Fatalf("expected AddBlockedBy to be called for all blockers, got %v", blockedCalls)
+	}
+
+	expectedSummary := "link summary: parent=failed blocked_by_added=0/2 partial_success=no\n"
+	if out != expectedSummary {
+		t.Fatalf("unexpected summary\nexpected:\n%s\nactual:\n%s", expectedSummary, out)
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "parent failure") || !strings.Contains(errMsg, "blocked-by failure 9") || !strings.Contains(errMsg, "blocked-by failure 11") {
+		t.Fatalf("expected aggregated error to include all failures, got: %s", errMsg)
 	}
 
 	data, readErr := os.ReadFile(path)

--- a/cmd/ghi/main.go
+++ b/cmd/ghi/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -443,24 +444,30 @@ func runLink(cmd *cobra.Command, args []string) error {
 
 	blockedByAdded := 0
 	anyRemoteSuccess := false
+	remoteErrors := make([]error, 0, 1+len(blockedByToCreate))
 
 	if parentStatus == "pending" {
 		if err := addSubIssueFn(issueNumber, strconv.Itoa(*parent)); err != nil {
 			parentStatus = "failed"
-			fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), anyRemoteSuccess))
-			return model.NewEnvError("", err)
+			remoteErrors = append(remoteErrors, fmt.Errorf("failed to add parent link: %w", err))
+		} else {
+			parentStatus = "added"
+			anyRemoteSuccess = true
 		}
-		parentStatus = "added"
-		anyRemoteSuccess = true
 	}
 
 	for _, blocker := range blockedByToCreate {
 		if err := addBlockedByFn(issueNumber, strconv.Itoa(blocker)); err != nil {
-			fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), anyRemoteSuccess))
-			return model.NewEnvError("", err)
+			remoteErrors = append(remoteErrors, fmt.Errorf("failed to add blocked-by link #%d: %w", blocker, err))
+			continue
 		}
 		blockedByAdded++
 		anyRemoteSuccess = true
+	}
+
+	if len(remoteErrors) > 0 {
+		fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), anyRemoteSuccess))
+		return model.NewEnvError("", errors.Join(remoteErrors...))
 	}
 
 	if parentStatus == "added" {

--- a/cmd/ghi/main.go
+++ b/cmd/ghi/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 const issuesDir = "issues"
 
 var addSubIssueFn = gh.AddSubIssue
+var addBlockedByFn = gh.AddBlockedBy
 
 var rootCmd = &cobra.Command{
 	Use:   "ghi",
@@ -66,8 +68,8 @@ var reopenCmd = &cobra.Command{
 }
 
 var linkCmd = &cobra.Command{
-	Use:   "link <child> --parent <parent>",
-	Short: "Link a child issue under a parent issue",
+	Use:   "link <issue> [--parent <parent>] [--blocked-by <issue> ...]",
+	Short: "Link parent and dependency relationships for an issue",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runLink,
 }
@@ -94,8 +96,10 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(closeCmd)
 	rootCmd.AddCommand(reopenCmd)
-	linkCmd.Flags().String("parent", "", "Parent issue number")
-	linkCmd.MarkFlagRequired("parent")
+	linkCmd.Flags().String("parent", "", "Parent issue number or GitHub issue URL")
+	linkCmd.Flags().StringArray("blocked-by", nil, "Issue number or GitHub issue URL that blocks this issue (repeatable)")
+	linkCmd.Flags().StringArray("depends-on", nil, "Unsupported option; use --blocked-by")
+	_ = linkCmd.Flags().MarkHidden("depends-on")
 	rootCmd.AddCommand(linkCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(pruneCmd)
@@ -348,22 +352,57 @@ func runReopen(cmd *cobra.Command, args []string) error {
 }
 
 func runLink(cmd *cobra.Command, args []string) error {
-	child := args[0]
-	parent, _ := cmd.Flags().GetString("parent")
+	const usage = "Usage: ghi link <issue> [--parent <parent>] [--blocked-by <issue> ...]"
 
-	if parent == "" || !model.IsNumeric(child) || !model.IsNumeric(parent) {
-		return model.NewUsageError("Usage: ghi link <child> --parent <parent>")
+	dependsOn, _ := cmd.Flags().GetStringArray("depends-on")
+	if len(dependsOn) > 0 {
+		return model.NewUsageError(usage + "\n--depends-on is not supported. Use --blocked-by instead.")
 	}
 
-	if child == parent {
+	issue, err := normalizeIssueReference(args[0])
+	if err != nil {
+		return model.NewUsageError(usage)
+	}
+
+	parentRaw, _ := cmd.Flags().GetString("parent")
+	var parent *int
+	if strings.TrimSpace(parentRaw) != "" {
+		parentIssue, err := normalizeIssueReference(parentRaw)
+		if err != nil {
+			return model.NewUsageError(usage)
+		}
+		parent = &parentIssue
+	}
+
+	blockedByRaw, _ := cmd.Flags().GetStringArray("blocked-by")
+	blockedBy, err := normalizeIssueReferences(blockedByRaw)
+	if err != nil {
+		return model.NewUsageError(usage)
+	}
+
+	if parent == nil && len(blockedBy) == 0 {
+		return model.NewUsageError(usage)
+	}
+
+	if parent != nil && issue == *parent {
 		return model.NewUsageError("Usage: child and parent issue numbers must differ")
 	}
 
-	filePath := filepath.Join(issuesDir, fmt.Sprintf("%s.md", child))
+	for _, blocker := range blockedBy {
+		if blocker == issue {
+			return model.NewUsageError("Usage: --blocked-by cannot include the target issue")
+		}
+		if parent != nil && blocker == *parent {
+			return model.NewUsageError("Usage: --blocked-by cannot include --parent")
+		}
+	}
+
+	issueNumber := strconv.Itoa(issue)
+	filePath := filepath.Join(issuesDir, fmt.Sprintf("%s.md", issueNumber))
 	raw, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return model.NewIOError(fmt.Sprintf("%s not found. Run 'ghi pull %s' first", filePath, child), err)
+			return model.NewIOError(fmt.Sprintf("%s not found. Run 'ghi pull %s' first", filePath, issueNumber), err)
 		}
 		return model.NewIOError("failed to read issue file", err)
 	}
@@ -376,28 +415,143 @@ func runLink(cmd *cobra.Command, args []string) error {
 		return model.NewIOError("failed to parse markdown", err)
 	}
 
-	parentInt, _ := strconv.Atoi(parent)
-	if fm.HasParent(parentInt) {
-		fmt.Printf("%s already linked to parent #%s; no changes made\n", filePath, parent)
-		return nil
+	existingBlockedBy, err := fm.BlockedBy()
+	if err != nil {
+		return model.NewIOError(fmt.Sprintf("Invalid frontmatter in %s", filePath), err)
 	}
 
-	if err := addSubIssueFn(child, parent); err != nil {
-		return model.NewEnvError("", err)
+	parentStatus := "not-requested"
+	if parent != nil {
+		if fm.HasParent(*parent) {
+			parentStatus = "unchanged"
+		} else {
+			parentStatus = "pending"
+		}
 	}
 
-	fm.SetParent(parentInt)
+	existingBlockers := make(map[int]struct{}, len(existingBlockedBy))
+	for _, value := range existingBlockedBy {
+		existingBlockers[value] = struct{}{}
+	}
+
+	blockedByToCreate := make([]int, 0, len(blockedBy))
+	for _, value := range blockedBy {
+		if _, exists := existingBlockers[value]; !exists {
+			blockedByToCreate = append(blockedByToCreate, value)
+		}
+	}
+
+	blockedByAdded := 0
+	anyRemoteSuccess := false
+
+	if parentStatus == "pending" {
+		if err := addSubIssueFn(issueNumber, strconv.Itoa(*parent)); err != nil {
+			parentStatus = "failed"
+			fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), anyRemoteSuccess))
+			return model.NewEnvError("", err)
+		}
+		parentStatus = "added"
+		anyRemoteSuccess = true
+	}
+
+	for _, blocker := range blockedByToCreate {
+		if err := addBlockedByFn(issueNumber, strconv.Itoa(blocker)); err != nil {
+			fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), anyRemoteSuccess))
+			return model.NewEnvError("", err)
+		}
+		blockedByAdded++
+		anyRemoteSuccess = true
+	}
+
+	if parentStatus == "added" {
+		fm.SetParent(*parent)
+	}
+
+	if len(blockedBy) > 0 {
+		merged := append(append([]int{}, existingBlockedBy...), blockedBy...)
+		fm.SetBlockedBy(merged)
+	}
+
 	content, err := filefmt.EncodeFrontmatterDoc(fm, body)
 	if err != nil {
-		return model.NewIOError("sub-issue linked but failed to encode markdown", err)
+		return model.NewIOError("issue links updated on GitHub but failed to encode markdown", err)
 	}
 
 	if err := filefmt.AtomicWriteFile(filePath, content, 0o644); err != nil {
-		return model.NewIOError("sub-issue linked on GitHub but failed to update local file; manually add the same parent to the frontmatter to restore consistency", err)
+		return model.NewIOError("issue links updated on GitHub but failed to update local file; manually align frontmatter to restore consistency", err)
 	}
 
-	fmt.Printf("Linked #%s under #%s and updated %s\n", child, parent, filePath)
+	fmt.Println(linkSummaryLine(parentStatus, blockedByAdded, len(blockedBy), false))
 	return nil
+}
+
+func normalizeIssueReferences(rawReferences []string) ([]int, error) {
+	values := make([]int, 0, len(rawReferences))
+	for _, raw := range rawReferences {
+		value, err := normalizeIssueReference(raw)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+
+	return model.NormalizeIssueNumbers(values), nil
+}
+
+func normalizeIssueReference(raw string) (int, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" {
+		return 0, fmt.Errorf("empty issue reference")
+	}
+
+	if model.IsNumeric(ref) {
+		n, err := strconv.Atoi(ref)
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid issue number")
+		}
+		return n, nil
+	}
+
+	parsed, err := url.Parse(ref)
+	if err != nil {
+		return 0, fmt.Errorf("invalid issue URL: %w", err)
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return 0, fmt.Errorf("unsupported URL scheme")
+	}
+
+	host := strings.ToLower(parsed.Host)
+	if host != "github.com" && host != "www.github.com" {
+		return 0, fmt.Errorf("unsupported issue URL host")
+	}
+
+	pathParts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(pathParts) != 4 || pathParts[2] != "issues" || !model.IsNumeric(pathParts[3]) {
+		return 0, fmt.Errorf("unsupported issue URL path")
+	}
+
+	n, err := strconv.Atoi(pathParts[3])
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid issue URL number")
+	}
+
+	return n, nil
+}
+
+func linkSummaryLine(parentStatus string, blockedByAdded, blockedByRequested int, partialSuccess bool) string {
+	partial := "no"
+	if partialSuccess {
+		partial = "yes"
+	}
+
+	return fmt.Sprintf(
+		"link summary: parent=%s blocked_by_added=%d/%d partial_success=%s",
+		parentStatus,
+		blockedByAdded,
+		blockedByRequested,
+		partial,
+	)
 }
 
 func runList(cmd *cobra.Command, args []string) error {

--- a/internal/filefmt/md.go
+++ b/internal/filefmt/md.go
@@ -61,6 +61,37 @@ func (fm *FrontmatterDoc) HasParent(parent int) bool {
 	return *current == parent
 }
 
+// BlockedBy returns blocked_by values after normalization.
+func (fm *FrontmatterDoc) BlockedBy() ([]int, error) {
+	for i := 0; i+1 < len(fm.mapping.Content); i += 2 {
+		if fm.mapping.Content[i].Value != "blocked_by" {
+			continue
+		}
+
+		valueNode := fm.mapping.Content[i+1]
+		if valueNode.Kind != yaml.SequenceNode {
+			return nil, fmt.Errorf("invalid blocked_by value: must be a sequence")
+		}
+
+		values := make([]int, 0, len(valueNode.Content))
+		for _, item := range valueNode.Content {
+			if item.Kind != yaml.ScalarNode {
+				return nil, fmt.Errorf("invalid blocked_by entry: must be an integer")
+			}
+
+			value, err := strconv.Atoi(strings.TrimSpace(item.Value))
+			if err != nil || value <= 0 {
+				return nil, fmt.Errorf("invalid blocked_by entry: %q", item.Value)
+			}
+			values = append(values, value)
+		}
+
+		return model.NormalizeIssueNumbers(values), nil
+	}
+
+	return nil, nil
+}
+
 // SetParent removes any existing parent entry and appends a new one at the end
 // while leaving other keys and their order intact.
 func (fm *FrontmatterDoc) SetParent(parent int) {
@@ -77,6 +108,36 @@ func (fm *FrontmatterDoc) SetParent(parent int) {
 	key := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "parent"}
 	val := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(parent)}
 	fm.mapping.Content = append(fm.mapping.Content, key, val)
+}
+
+// SetBlockedBy removes any existing blocked_by entry and appends a normalized
+// one at the end while leaving other keys and their order intact.
+func (fm *FrontmatterDoc) SetBlockedBy(blockedBy []int) {
+	normalized := model.NormalizeIssueNumbers(blockedBy)
+
+	cleaned := make([]*yaml.Node, 0, len(fm.mapping.Content))
+	for i := 0; i+1 < len(fm.mapping.Content); i += 2 {
+		if fm.mapping.Content[i].Value == "blocked_by" {
+			continue
+		}
+		cleaned = append(cleaned, fm.mapping.Content[i], fm.mapping.Content[i+1])
+	}
+	fm.mapping.Content = cleaned
+
+	if len(normalized) == 0 {
+		return
+	}
+
+	key := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "blocked_by"}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Style: yaml.FlowStyle}
+	for _, issueNumber := range normalized {
+		seq.Content = append(seq.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: strconv.Itoa(issueNumber),
+		})
+	}
+	fm.mapping.Content = append(fm.mapping.Content, key, seq)
 }
 
 func EncodeMarkdown(fm model.Frontmatter, body []byte) ([]byte, error) {

--- a/internal/filefmt/md_test.go
+++ b/internal/filefmt/md_test.go
@@ -36,3 +36,62 @@ func TestEncodeMarkdownOmitsParentWhenUnset(t *testing.T) {
 		t.Fatalf("frontmatter without parent mismatch\nexpected:\n%s\nactual:\n%s", expected, string(got))
 	}
 }
+
+func TestFrontmatterDocBlockedByNormalizesValues(t *testing.T) {
+	raw := []byte("---\ntitle: Child issue\nblocked_by:\n  - 5\n  - 3\n  - 5\n---\nbody")
+
+	fm, _, err := DecodeMarkdown(raw)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+
+	got, err := fm.BlockedBy()
+	if err != nil {
+		t.Fatalf("unexpected blocked_by parse error: %v", err)
+	}
+
+	want := []int{3, 5}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected blocked_by length: got=%v want=%v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected blocked_by values: got=%v want=%v", got, want)
+		}
+	}
+}
+
+func TestFrontmatterDocSetBlockedByPreservesUnknownKeyOrder(t *testing.T) {
+	raw := []byte("---\ntitle: Child issue\nlabels:\n  - bug\nblocked_by: [8, 4]\ncustom: keep\n---\nbody")
+
+	fm, body, err := DecodeMarkdown(raw)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+
+	fm.SetBlockedBy([]int{7, 4, 7, 1})
+
+	content, err := EncodeFrontmatterDoc(fm, body)
+	if err != nil {
+		t.Fatalf("unexpected encode error: %v", err)
+	}
+
+	expected := "---\ntitle: Child issue\nlabels:\n  - bug\ncustom: keep\nblocked_by: [1, 4, 7]\n---\nbody"
+	if string(content) != expected {
+		t.Fatalf("frontmatter order/content mismatch\nexpected:\n%s\nactual:\n%s", expected, string(content))
+	}
+}
+
+func TestFrontmatterDocBlockedByRejectsInvalidValues(t *testing.T) {
+	raw := []byte("---\ntitle: Child issue\nblocked_by: [3, nope]\n---\nbody")
+
+	fm, _, err := DecodeMarkdown(raw)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+
+	if _, err := fm.BlockedBy(); err == nil {
+		t.Fatalf("expected blocked_by parse error")
+	}
+}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -211,6 +211,16 @@ func RunGitDiff(localPath, remotePath string, extraArgs []string) (int, error) {
 	return 0, nil
 }
 
+type linkMutationType string
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+const (
+	linkMutationSubIssue  linkMutationType = "sub_issue"
+	linkMutationBlockedBy linkMutationType = "blocked_by"
+)
+
 func GetIssueID(issueNumber string) (string, error) {
 	if err := checkGHAvailable(); err != nil {
 		return "", err
@@ -224,12 +234,19 @@ func GetIssueID(issueNumber string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
 	defer cancel()
 
-	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s", owner, repo, issueNumber)
-	cmd := commandContext(ctx, "gh", "api",
-		"-H", "Accept: application/vnd.github+json",
-		"-H", "X-GitHub-Api-Version: 2022-11-28",
-		apiPath,
-		"--jq", ".id",
+	query := `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      id
+    }
+  }
+}`
+
+	cmd := commandContext(ctx, "gh", "api", "graphql",
+		"-f", "query="+query,
+		"-f", "owner="+owner,
+		"-f", "name="+repo,
+		"-F", "number="+issueNumber,
 	)
 
 	var stdout, stderr bytes.Buffer
@@ -238,7 +255,7 @@ func GetIssueID(issueNumber string) (string, error) {
 
 	if err := cmd.Run(); err != nil {
 		stderrStr := strings.TrimSpace(stderr.String())
-		if strings.Contains(stderrStr, "404") {
+		if strings.Contains(stderrStr, "404") || strings.Contains(strings.ToLower(stderrStr), "not found") {
 			return "", fmt.Errorf("gh error: issue #%s not found", issueNumber)
 		}
 		if strings.Contains(stderrStr, "authentication") || strings.Contains(stderrStr, "401") {
@@ -247,12 +264,34 @@ func GetIssueID(issueNumber string) (string, error) {
 		return "", fmt.Errorf("gh error: %s", stderrStr)
 	}
 
-	id := strings.TrimSpace(stdout.String())
-	if id == "" {
+	var response struct {
+		Data struct {
+			Repository struct {
+				Issue *struct {
+					ID string `json:"id"`
+				} `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+		Errors []graphQLError `json:"errors"`
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return "", fmt.Errorf("failed to parse gh output: %w", err)
+	}
+
+	if len(response.Errors) > 0 && response.Data.Repository.Issue == nil {
+		errorText := collectGraphQLErrorMessages(response.Errors)
+		if strings.Contains(errorText, "Could not resolve to an Issue") {
+			return "", fmt.Errorf("gh error: issue #%s not found", issueNumber)
+		}
+		return "", fmt.Errorf("gh error: %s", errorText)
+	}
+
+	if response.Data.Repository.Issue == nil || strings.TrimSpace(response.Data.Repository.Issue.ID) == "" {
 		return "", fmt.Errorf("gh error: issue id missing for #%s", issueNumber)
 	}
 
-	return id, nil
+	return response.Data.Repository.Issue.ID, nil
 }
 
 func AddSubIssue(childNumber, parentNumber string) error {
@@ -269,42 +308,133 @@ func AddSubIssue(childNumber, parentNumber string) error {
 		return err
 	}
 
-	owner, repo, err := GetRepositoryInfo()
+	parentID, err := GetIssueID(parentNumber)
 	if err != nil {
 		return err
+	}
+
+	mutation := `mutation($issueId: ID!, $subIssueId: ID!) {
+  addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId, replaceParent: true}) {
+    clientMutationId
+  }
+}`
+
+	return runIssueLinkMutation(
+		linkMutationSubIssue,
+		mutation,
+		"issueId", parentID,
+		"subIssueId", childID,
+	)
+}
+
+func AddBlockedBy(issueNumber, blockingIssueNumber string) error {
+	if err := checkGHAvailable(); err != nil {
+		return err
+	}
+
+	if issueNumber == blockingIssueNumber {
+		return fmt.Errorf("issue and blocking issue cannot be the same")
+	}
+
+	issueID, err := GetIssueID(issueNumber)
+	if err != nil {
+		return err
+	}
+
+	blockingIssueID, err := GetIssueID(blockingIssueNumber)
+	if err != nil {
+		return err
+	}
+
+	mutation := `mutation($issueId: ID!, $blockingIssueId: ID!) {
+  addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
+    clientMutationId
+  }
+}`
+
+	return runIssueLinkMutation(
+		linkMutationBlockedBy,
+		mutation,
+		"issueId", issueID,
+		"blockingIssueId", blockingIssueID,
+	)
+}
+
+func runIssueLinkMutation(mutationType linkMutationType, mutation string, variablePairs ...string) error {
+	if len(variablePairs)%2 != 0 {
+		return fmt.Errorf("internal error: variable pairs must be key/value")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
 	defer cancel()
 
-	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s/sub_issues", owner, repo, parentNumber)
-	cmd := commandContext(ctx, "gh", "api", "--method", "POST",
-		"-H", "Accept: application/vnd.github+json",
-		"-H", "X-GitHub-Api-Version: 2022-11-28",
-		apiPath,
-		"-F", "sub_issue_id="+childID,
-	)
+	args := []string{"api", "graphql", "-H", "GraphQL-Features: sub_issues", "-f", "query=" + mutation}
+	for i := 0; i < len(variablePairs); i += 2 {
+		key := variablePairs[i]
+		value := variablePairs[i+1]
+		args = append(args, "-f", key+"="+value)
+	}
 
-	var stderr bytes.Buffer
+	cmd := commandContext(ctx, "gh", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		stderrStr := strings.TrimSpace(stderr.String())
-		switch {
-		case strings.Contains(stderrStr, "401") || strings.Contains(strings.ToLower(stderrStr), "authentication"):
-			return fmt.Errorf("gh error: authentication required (HTTP 401)")
-		case strings.Contains(stderrStr, "403"):
-			return fmt.Errorf("gh error: forbidden: ensure sub-issues are enabled and you have permissions (HTTP 403)")
-		case strings.Contains(stderrStr, "404"):
-			return fmt.Errorf("gh error: parent issue not found or sub-issues disabled (HTTP 404)")
-		case strings.Contains(stderrStr, "422"):
-			return fmt.Errorf("gh error: sub-issue request rejected (HTTP 422): %s", stderrStr)
-		default:
-			return fmt.Errorf("gh error: %s", stderrStr)
-		}
+		return mapIssueLinkError(mutationType, strings.TrimSpace(stderr.String()))
+	}
+
+	var response struct {
+		Errors []graphQLError `json:"errors"`
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return fmt.Errorf("failed to parse gh output: %w", err)
+	}
+
+	if len(response.Errors) > 0 {
+		return mapIssueLinkError(mutationType, collectGraphQLErrorMessages(response.Errors))
 	}
 
 	return nil
+}
+
+func collectGraphQLErrorMessages(errors []graphQLError) string {
+	messages := make([]string, 0, len(errors))
+	for _, entry := range errors {
+		if strings.TrimSpace(entry.Message) != "" {
+			messages = append(messages, strings.TrimSpace(entry.Message))
+		}
+	}
+
+	return strings.Join(messages, "; ")
+}
+
+func mapIssueLinkError(mutationType linkMutationType, raw string) error {
+	lower := strings.ToLower(raw)
+
+	switch {
+	case strings.Contains(raw, "401") || strings.Contains(lower, "authentication") || strings.Contains(lower, "unauthorized"):
+		return fmt.Errorf("gh error: authentication required (HTTP 401)")
+	case strings.Contains(raw, "403") || strings.Contains(lower, "forbidden") || strings.Contains(lower, "resource not accessible"):
+		if mutationType == linkMutationSubIssue {
+			return fmt.Errorf("gh error: forbidden: ensure sub-issues are enabled and you have permissions (HTTP 403)")
+		}
+		return fmt.Errorf("gh error: forbidden: ensure issue dependencies are enabled and you have permissions (HTTP 403)")
+	case strings.Contains(raw, "404") || strings.Contains(lower, "not found") || strings.Contains(lower, "could not resolve"):
+		if mutationType == linkMutationSubIssue {
+			return fmt.Errorf("gh error: parent issue not found or sub-issues disabled (HTTP 404)")
+		}
+		return fmt.Errorf("gh error: dependency issue not found (HTTP 404)")
+	case strings.Contains(raw, "422") || strings.Contains(lower, "unprocessable"):
+		if mutationType == linkMutationSubIssue {
+			return fmt.Errorf("gh error: sub-issue request rejected (HTTP 422): %s", raw)
+		}
+		return fmt.Errorf("gh error: dependency request rejected (HTTP 422): %s", raw)
+	default:
+		return fmt.Errorf("gh error: %s", raw)
+	}
 }
 
 func GetRepositoryInfo() (owner string, repo string, err error) {

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -43,7 +43,7 @@ func TestAddSubIssueSuccess(t *testing.T) {
 	reset := stubGH(t)
 	defer reset()
 
-	t.Setenv("GH_HELPER_ISSUE_ID", "12345")
+	t.Setenv("GH_HELPER_ISSUE_ID", "ISSUE_NODE_ID")
 	t.Setenv("GH_HELPER_SUBISSUE_STATUS", "200")
 
 	if err := AddSubIssue("5", "7"); err != nil {
@@ -67,10 +67,52 @@ func TestAddSubIssueHTTPFailures(t *testing.T) {
 			reset := stubGH(t)
 			defer reset()
 
-			t.Setenv("GH_HELPER_ISSUE_ID", "98765")
+			t.Setenv("GH_HELPER_ISSUE_ID", "ISSUE_NODE_ID")
 			t.Setenv("GH_HELPER_SUBISSUE_STATUS", tc.status)
 
 			err := AddSubIssue("5", "7")
+			if err == nil {
+				t.Fatalf("expected error for status %s, got nil", tc.status)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("unexpected error message: %v", err)
+			}
+		})
+	}
+}
+
+func TestAddBlockedBySuccess(t *testing.T) {
+	reset := stubGH(t)
+	defer reset()
+
+	t.Setenv("GH_HELPER_ISSUE_ID", "ISSUE_NODE_ID")
+	t.Setenv("GH_HELPER_BLOCKEDBY_STATUS", "200")
+
+	if err := AddBlockedBy("5", "7"); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+}
+
+func TestAddBlockedByHTTPFailures(t *testing.T) {
+	testCases := []struct {
+		status string
+		want   string
+	}{
+		{"404", "404"},
+		{"422", "422"},
+		{"401", "401"},
+		{"403", "403"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.status, func(t *testing.T) {
+			reset := stubGH(t)
+			defer reset()
+
+			t.Setenv("GH_HELPER_ISSUE_ID", "ISSUE_NODE_ID")
+			t.Setenv("GH_HELPER_BLOCKEDBY_STATUS", tc.status)
+
+			err := AddBlockedBy("5", "7")
 			if err == nil {
 				t.Fatalf("expected error for status %s, got nil", tc.status)
 			}
@@ -89,6 +131,7 @@ func TestGetIssueIDHandlesErrors(t *testing.T) {
 	}{
 		{name: "not found", status: "404", match: "not found"},
 		{name: "auth", status: "401", match: "authentication"},
+		{name: "graphql not found", status: "gql-not-found", match: "not found"},
 		{name: "missing id", status: "empty", match: "issue id missing"},
 	}
 
@@ -130,60 +173,68 @@ func TestHelperProcess(t *testing.T) {
 	}
 
 	cmdArgs := args[sep+1:]
-	if len(cmdArgs) == 0 || cmdArgs[0] != "gh" {
+	if len(cmdArgs) < 3 || cmdArgs[0] != "gh" || cmdArgs[1] != "api" || cmdArgs[2] != "graphql" {
 		fmt.Fprintf(os.Stderr, "unexpected command: %v", cmdArgs)
 		os.Exit(1)
 	}
 
-	if len(cmdArgs) > 1 && cmdArgs[1] == "api" {
-		joined := strings.Join(cmdArgs, " ")
-		if strings.Contains(joined, "sub_issues") {
-			if !strings.Contains(joined, "sub_issue_id=") {
-				fmt.Fprint(os.Stderr, "missing sub_issue_id flag")
-				os.Exit(1)
-			}
-			status := os.Getenv("GH_HELPER_SUBISSUE_STATUS")
-			switch status {
-			case "404":
-				fmt.Fprint(os.Stderr, "HTTP 404: Not Found")
-				os.Exit(1)
-			case "422":
-				fmt.Fprint(os.Stderr, "HTTP 422: Unprocessable Entity")
-				os.Exit(1)
-			case "401":
-				fmt.Fprint(os.Stderr, "HTTP 401: Unauthorized")
-				os.Exit(1)
-			case "403":
-				fmt.Fprint(os.Stderr, "HTTP 403: Forbidden")
-				os.Exit(1)
-			default:
-				os.Exit(0)
-			}
-		}
+	joined := strings.Join(cmdArgs, " ")
 
-		if strings.Contains(joined, "--jq .id") {
-			status := os.Getenv("GH_HELPER_ISSUE_STATUS")
-			switch status {
-			case "404":
-				fmt.Fprint(os.Stderr, "HTTP 404: Not Found")
-				os.Exit(1)
-			case "401":
-				fmt.Fprint(os.Stderr, "HTTP 401: Unauthorized")
-				os.Exit(1)
-			case "empty":
-				fmt.Fprint(os.Stdout, "")
-				os.Exit(0)
-			}
+	if strings.Contains(joined, "addSubIssue(input:") {
+		status := os.Getenv("GH_HELPER_SUBISSUE_STATUS")
+		emitMutationStatus(status, "addSubIssue")
+	}
 
-			id := os.Getenv("GH_HELPER_ISSUE_ID")
-			if id == "" {
-				id = "123"
-			}
-			fmt.Fprint(os.Stdout, id)
+	if strings.Contains(joined, "addBlockedBy(input:") {
+		status := os.Getenv("GH_HELPER_BLOCKEDBY_STATUS")
+		emitMutationStatus(status, "addBlockedBy")
+	}
+
+	if strings.Contains(joined, "issue(number: $number)") {
+		status := os.Getenv("GH_HELPER_ISSUE_STATUS")
+		switch status {
+		case "404":
+			fmt.Fprint(os.Stderr, "HTTP 404: Not Found")
+			os.Exit(1)
+		case "401":
+			fmt.Fprint(os.Stderr, "HTTP 401: Unauthorized")
+			os.Exit(1)
+		case "gql-not-found":
+			fmt.Fprint(os.Stdout, `{"data":{"repository":{"issue":null}},"errors":[{"message":"Could not resolve to an Issue with the number of 123."}]}`)
+			os.Exit(0)
+		case "empty":
+			fmt.Fprint(os.Stdout, `{"data":{"repository":{"issue":{"id":""}}}}`)
 			os.Exit(0)
 		}
+
+		id := os.Getenv("GH_HELPER_ISSUE_ID")
+		if id == "" {
+			id = "ISSUE_NODE_ID"
+		}
+		fmt.Fprintf(os.Stdout, `{"data":{"repository":{"issue":{"id":"%s"}}}}`, id)
+		os.Exit(0)
 	}
 
 	fmt.Fprintf(os.Stderr, "unhandled gh command: %v", cmdArgs)
 	os.Exit(1)
+}
+
+func emitMutationStatus(status, mutationName string) {
+	switch status {
+	case "404":
+		fmt.Fprint(os.Stderr, "HTTP 404: Not Found")
+		os.Exit(1)
+	case "422":
+		fmt.Fprint(os.Stderr, "HTTP 422: Unprocessable Entity")
+		os.Exit(1)
+	case "401":
+		fmt.Fprint(os.Stderr, "HTTP 401: Unauthorized")
+		os.Exit(1)
+	case "403":
+		fmt.Fprint(os.Stderr, "HTTP 403: Forbidden")
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stdout, `{"data":{"%s":{"clientMutationId":"ok"}}}`, mutationName)
+		os.Exit(0)
+	}
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 )
 
 type Frontmatter struct {
-	Title  string `yaml:"title,omitempty"`
-	Parent *int   `yaml:"parent,omitempty"`
+	Title     string `yaml:"title,omitempty"`
+	Parent    *int   `yaml:"parent,omitempty"`
+	BlockedBy []int  `yaml:"blocked_by,omitempty"`
 }
 
 type ErrorType int
@@ -49,6 +51,35 @@ var numericRegex = regexp.MustCompile(`^[0-9]+$`)
 
 func IsNumeric(s string) bool {
 	return numericRegex.MatchString(s)
+}
+
+func NormalizeIssueNumbers(values []int) []int {
+	if len(values) == 0 {
+		return nil
+	}
+
+	normalized := make([]int, 0, len(values))
+	for _, value := range values {
+		if value <= 0 {
+			continue
+		}
+		normalized = append(normalized, value)
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	sort.Ints(normalized)
+
+	out := normalized[:1]
+	for _, value := range normalized[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+
+	return out
 }
 
 type IssueData struct {


### PR DESCRIPTION
## 概要
`ghi link` に `--blocked-by` を追加し、`--parent` と組み合わせた親子リンク/依存リンクの作成を 1 コマンドで扱えるようにしました。入力バリデーション、API 実行、frontmatter 更新、失敗時制御までを一貫して拡張しています。

## 変更点
- `link` コマンド定義を更新し、`--parent` を任意化、`--blocked-by` の複数指定対応、`--depends-on` を非対応として usage エラー化。
- `runLink` に番号/URL 正規化と事前バリデーションを追加し、`issue==parent` や `blocked-by` の不正組み合わせを API 呼び出し前に `exit 1` で拒否。
- GitHub 連携を GraphQL mutation 経路で実装し、sub-issue / blocked-by の両リンク作成と relation 種別ごとのエラーマッピングに対応。
- `blocked_by` frontmatter のマージ・重複除去・昇順保存を実装し、リモート更新成功時のみローカルを更新。
- `--parent` と `--blocked-by` 同時指定時は両経路を試行し、失敗は `errors.Join` で集約。API 失敗時は 1 行サマリ出力で `exit 2`、ローカル未更新を保証。

## 動作確認
- `go test ./cmd/ghi -run Link` を実行し、parent のみ / blocked-by のみ / 同時指定 / 未指定 / `--depends-on` / 事前バリデーション / API 失敗時挙動を確認。
- `go test ./internal/gh -run SubIssue` と依存リンク系テストを実行し、GraphQL mutation の成功系・HTTP エラー系・ID 取得エラー系を確認。
- `go test ./internal/filefmt` を実行し、`blocked_by` の正規化・順序保持・不正値検知を確認。
- 手動で `ghi link 210 --parent 153 --blocked-by 201 --blocked-by 202` を実行し、1 行サマリ出力と frontmatter 更新条件を確認。

## 影響範囲/リスク
- 影響範囲は `cmd/ghi/main.go`、`internal/gh/gh.go`、`internal/filefmt/md.go`、`internal/model/types.go`、関連テスト。
- GitHub GraphQL の依存リンク mutation 失敗時は `exit 2` となり、ローカル frontmatter を更新しない挙動に統一。
- `link` の終了コード運用（usage 系 `exit 1`、API 失敗 `exit 2`）が既存の自動化判定条件に影響する可能性。

## 関連/クローズ
Closes #20